### PR TITLE
Add Flatpak build manifest

### DIFF
--- a/flatpak/io.github.Noethys.Noethys.yaml
+++ b/flatpak/io.github.Noethys.Noethys.yaml
@@ -1,0 +1,23 @@
+app-id: io.github.Noethys.Noethys
+runtime: org.freedesktop.Platform
+runtime-version: '22.08'
+sdk: org.freedesktop.Sdk
+command: noethys
+finish-args:
+  - --share=ipc
+  - --socket=x11
+  - --socket=wayland
+  - --device=dri
+  - --filesystem=home
+modules:
+  - name: noethys
+    buildsystem: simple
+    build-commands:
+      - pip3 install --prefix=/app --no-cache-dir -r requirements.txt
+      - pip3 install --prefix=/app --no-cache-dir wxPython==4.2.1
+      - mkdir -p /app/share/noethys
+      - cp -r noethys/* /app/share/noethys/
+      - install -Dm755 flatpak/noethys-wrapper.sh /app/bin/noethys
+    sources:
+      - type: dir
+        path: ..

--- a/flatpak/noethys-wrapper.sh
+++ b/flatpak/noethys-wrapper.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec python3 /app/share/noethys/Noethys.py "$@"


### PR DESCRIPTION
## Summary
- provide simple wrapper script to start Noethys under Flatpak
- add a Flatpak manifest that installs dependencies and copies application sources

## Testing
- `python3 -m py_compile noethys/Noethys.py`


------
https://chatgpt.com/codex/tasks/task_e_684162a68a3483309a5cbbbdb7557b6a